### PR TITLE
feat: set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -7,8 +7,14 @@
   },
   "targetDefaults": {
     "build": {
-      "outputs": ["{projectRoot}/dist"],
-      "inputs": ["default", "^default"]
+      "outputs": [
+        "{projectRoot}/dist"
+      ],
+      "inputs": [
+        "default",
+        "^default"
+      ]
     }
-  }
+  },
+  "nxCloudId": "69e6c310df509183ea064bb3"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/69e6c30d336bedcb45c5ca1a/workspaces/69e6c310df509183ea064bb3

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.